### PR TITLE
After least versions, the package with least dependencies is chosen

### DIFF
--- a/mixology/version_solver.py
+++ b/mixology/version_solver.py
@@ -329,7 +329,11 @@ class VersionSolver:
             versions = self._source.versions_for(
                 term.package, term.constraint.constraint
             )
-            deps = self._source.dependencies_for(term.package, versions[0]) if versions else []
+            deps = (
+                self._source.dependencies_for(term.package, versions[0])
+                if versions
+                else []
+            )
             return len(versions), len(deps)
 
         if len(unsatisfied) == 1:

--- a/mixology/version_solver.py
+++ b/mixology/version_solver.py
@@ -324,10 +324,13 @@ class VersionSolver:
 
         # Prefer packages with as few remaining versions as possible,
         # so that if a conflict is necessary it's forced quickly.
+        # at a tie, the package with least dependencies is chosen
         def _get_min(term):
-            return len(
-                self._source.versions_for(term.package, term.constraint.constraint)
+            versions = self._source.versions_for(
+                term.package, term.constraint.constraint
             )
+            deps = self._source.dependencies_for(term.package, versions[0])
+            return len(versions), len(deps)
 
         if len(unsatisfied) == 1:
             term = unsatisfied[0]

--- a/mixology/version_solver.py
+++ b/mixology/version_solver.py
@@ -329,7 +329,7 @@ class VersionSolver:
             versions = self._source.versions_for(
                 term.package, term.constraint.constraint
             )
-            deps = self._source.dependencies_for(term.package, versions[0])
+            deps = self._source.dependencies_for(term.package, versions[0]) if versions else []
             return len(versions), len(deps)
 
         if len(unsatisfied) == 1:

--- a/tests/test_unsolvable.py
+++ b/tests/test_unsolvable.py
@@ -26,9 +26,9 @@ def test_no_version_that_matches_combined_constraints(source):
     source.add("shared", "3.5.0")
 
     error = """\
-Because foo (1.0.0) depends on shared (>=2.0.0 <3.0.0)
- and no versions of shared match >=2.9.0,<3.0.0, foo (1.0.0) requires shared (>=2.0.0,<2.9.0).
-And because bar (1.0.0) depends on shared (>=2.9.0 <4.0.0), bar (1.0.0) is incompatible with foo (1.0.0).
+Because no versions of shared match >=2.9.0,<3.0.0
+ and bar (1.0.0) depends on shared (>=2.9.0 <4.0.0), bar (1.0.0) requires shared (>=3.0.0,<4.0.0).
+And because foo (1.0.0) depends on shared (>=2.0.0 <3.0.0), bar (1.0.0) is incompatible with foo (1.0.0).
 So, because root depends on both foo (1.0.0) and bar (1.0.0), version solving failed."""
 
     check_solver_result(source, error=error)


### PR DESCRIPTION
This PR makes sure that first the package with least satisfying versions is chosen. If there are multiple packages with e.g. only one satisfying version, a second metric will decide the winner: the amount of dependencies of the highest satisfying version.

This way (if e.g. there are many dependencies with an exact pin), less dependencies need to be inspected before the next decision, improving solving time for big nested packages.

In my case, I'm using a PackageSource object that will on demand resolve the dependencies and available versions for a package by inspecting wheels from PyPI repositories. This adds overhead to the algorithm, but allows to start `solve()` with an empty (undiscovered) tree and one or more root dependencies. Getting wheels for packages with many dependencies takes a lot of time (and might be completely unnecessary if we inspect only few dependencies for a different term).